### PR TITLE
feat: 優先度一覧（priorities）・メンバー一覧（members）コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ redmine-cli delete-relation 443
 redmine-cli projects
 redmine-cli trackers
 redmine-cli statuses
+redmine-cli priorities
 redmine-cli categories --project myproject
 redmine-cli versions --project myproject
+redmine-cli members --project myproject
 ```
 
 ### 複数環境の切り替え

--- a/cmd/members.go
+++ b/cmd/members.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/spf13/cobra"
+)
+
+var membersCmd = &cobra.Command{
+	Use:   "members",
+	Short: "プロジェクトメンバー一覧を取得する",
+	RunE:  runMembers,
+}
+
+func init() {
+	membersCmd.Flags().String("project", "", "プロジェクトID (必須)")
+	_ = membersCmd.MarkFlagRequired("project")
+
+	rootCmd.AddCommand(membersCmd)
+}
+
+func runMembers(cmd *cobra.Command, args []string) error {
+	c, err := loadClientFromProfile()
+	if err != nil {
+		return err
+	}
+
+	project, _ := cmd.Flags().GetString("project")
+
+	var result any
+	path := fmt.Sprintf("/projects/%s/memberships.json", url.PathEscape(project))
+	if err := c.Get(path, nil, &result); err != nil {
+		return fmt.Errorf("メンバー取得エラー: %w", err)
+	}
+
+	return outputJSON(result)
+}

--- a/cmd/priorities.go
+++ b/cmd/priorities.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var prioritiesCmd = &cobra.Command{
+	Use:   "priorities",
+	Short: "優先度一覧を取得する",
+	RunE:  runPriorities,
+}
+
+func init() {
+	rootCmd.AddCommand(prioritiesCmd)
+}
+
+func runPriorities(cmd *cobra.Command, args []string) error {
+	c, err := loadClientFromProfile()
+	if err != nil {
+		return err
+	}
+
+	var result any
+	if err := c.Get("/enumerations/issue_priorities.json", nil, &result); err != nil {
+		return fmt.Errorf("優先度取得エラー: %w", err)
+	}
+
+	return outputJSON(result)
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,8 @@ Commands:
   statuses     ステータス一覧
   categories   カテゴリ一覧（要 --project）
   versions     バージョン一覧（要 --project）
+  priorities      優先度一覧
+  members         プロジェクトメンバー一覧（要 --project）
   create-issue    チケット作成（要 --project, --subject）
   add-relation    リレーション作成（要 --issue-id, --related-id, --type）
   delete-relation リレーション削除


### PR DESCRIPTION
## Why

create-issue 実装時に、優先度やプロジェクトメンバーの名称から ID を解決する手段が必要。

## What

- `priorities` コマンドを追加（GET /enumerations/issue_priorities.json）
- `members` コマンドを追加（GET /projects/:id/memberships.json、`--project` 必須）
- `docs/architecture.md`、`README.md` を更新

### As Is

優先度一覧・メンバー一覧を取得する CLI コマンドがない。

### To Be

`priorities` / `members` コマンドで JSON 形式の一覧を取得できる。

## Where

- `cmd/priorities.go`
- `cmd/members.go`
- `docs/architecture.md`
- `README.md`

## How

既存の cobra コマンドパターン（`loadClientFromProfile()` + `outputJSON()`）に従い、各エンドポイントを呼び出すコマンドを追加。

## Test plan

- [x] `go build` / `go test` / `go vet` 全パス
- [x] `priorities --profile field` で実際に優先度一覧取得を確認
- [x] `members --profile field --project 6` で実際にメンバー一覧取得を確認