### PR TITLE
feat(cmd): チケットの更新・削除・コメント記入コマンドを追加

### DIFF
--- a/cmd/delete_issue.go
+++ b/cmd/delete_issue.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var deleteIssueCmd = &cobra.Command{
+	Use:   "delete-issue <issue-id>",
+	Short: "チケットを削除する",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDeleteIssue,
+}
+
+func init() {
+	rootCmd.AddCommand(deleteIssueCmd)
+}
+
+func runDeleteIssue(cmd *cobra.Command, args []string) error {
+	issueID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("無効なチケットID: %s", args[0])
+	}
+
+	c, err := loadClientFromProfile()
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/issues/%d.json", issueID)
+	if err := c.Delete(path); err != nil {
+		return fmt.Errorf("チケット削除エラー: %w", err)
+	}
+
+	return outputJSON(map[string]string{"status": "deleted"})
+}

--- a/cmd/update_issue.go
+++ b/cmd/update_issue.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var updateIssueCmd = &cobra.Command{
+	Use:   "update-issue <issue-id>",
+	Short: "チケットを更新する",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runUpdateIssue,
+}
+
+func init() {
+	updateIssueCmd.Flags().Int("status-id", 0, "ステータス ID")
+	updateIssueCmd.Flags().Int("assigned-to-id", 0, "担当者 ID")
+	updateIssueCmd.Flags().Int("tracker-id", 0, "トラッカー ID")
+	updateIssueCmd.Flags().Int("priority-id", 0, "優先度 ID")
+	updateIssueCmd.Flags().String("subject", "", "題名")
+	updateIssueCmd.Flags().String("description", "", "説明")
+	updateIssueCmd.Flags().Int("category-id", 0, "カテゴリ ID")
+	updateIssueCmd.Flags().Int("version-id", 0, "対象バージョン ID")
+	updateIssueCmd.Flags().String("notes", "", "コメント")
+	updateIssueCmd.Flags().Bool("private-notes", false, "コメントを非公開にする")
+
+	rootCmd.AddCommand(updateIssueCmd)
+}
+
+func runUpdateIssue(cmd *cobra.Command, args []string) error {
+	issueID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("無効なチケットID: %s", args[0])
+	}
+
+	c, err := loadClientFromProfile()
+	if err != nil {
+		return err
+	}
+
+	issue := map[string]any{}
+
+	if cmd.Flags().Changed("status-id") {
+		v, _ := cmd.Flags().GetInt("status-id")
+		issue["status_id"] = v
+	}
+	if cmd.Flags().Changed("assigned-to-id") {
+		v, _ := cmd.Flags().GetInt("assigned-to-id")
+		issue["assigned_to_id"] = v
+	}
+	if cmd.Flags().Changed("tracker-id") {
+		v, _ := cmd.Flags().GetInt("tracker-id")
+		issue["tracker_id"] = v
+	}
+	if cmd.Flags().Changed("priority-id") {
+		v, _ := cmd.Flags().GetInt("priority-id")
+		issue["priority_id"] = v
+	}
+	if cmd.Flags().Changed("subject") {
+		v, _ := cmd.Flags().GetString("subject")
+		issue["subject"] = v
+	}
+	if cmd.Flags().Changed("description") {
+		v, _ := cmd.Flags().GetString("description")
+		issue["description"] = v
+	}
+	if cmd.Flags().Changed("category-id") {
+		v, _ := cmd.Flags().GetInt("category-id")
+		issue["category_id"] = v
+	}
+	if cmd.Flags().Changed("version-id") {
+		v, _ := cmd.Flags().GetInt("version-id")
+		issue["fixed_version_id"] = v
+	}
+	if cmd.Flags().Changed("notes") {
+		v, _ := cmd.Flags().GetString("notes")
+		issue["notes"] = v
+	}
+	if cmd.Flags().Changed("private-notes") {
+		v, _ := cmd.Flags().GetBool("private-notes")
+		issue["private_notes"] = v
+	}
+
+	if len(issue) == 0 {
+		return fmt.Errorf("更新するフィールドを1つ以上指定してください")
+	}
+
+	body := map[string]any{"issue": issue}
+	path := fmt.Sprintf("/issues/%d.json", issueID)
+	if err := c.Put(path, body); err != nil {
+		return fmt.Errorf("チケット更新エラー: %w", err)
+	}
+
+	return outputJSON(map[string]string{"status": "updated"})
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -75,6 +75,21 @@ func (c *Client) Post(path string, body any, result any) error {
 	return c.doRequest(req, result)
 }
 
+// Put は指定パスに対してPUTリクエストを送信します。
+func (c *Client) Put(path string, body any) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("リクエストボディのJSON変換エラー: %w", err)
+	}
+
+	u := c.baseURL + path
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, u, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("リクエスト作成エラー: %w", err)
+	}
+	return c.doRequest(req, nil)
+}
+
 // Delete は指定パスに対してDELETEリクエストを送信します。
 func (c *Client) Delete(path string) error {
 	u := c.baseURL + path

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -283,6 +283,58 @@ func TestPost_422FallbackOnInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestPut_SendsCorrectMethodAndBody(t *testing.T) {
+	var receivedMethod string
+	var receivedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-api-key")
+	body := map[string]any{"issue": map[string]any{"status_id": 5, "notes": "更新テスト"}}
+	err := c.Put("/issues/123.json", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedMethod != http.MethodPut {
+		t.Errorf("expected PUT method, got %s", receivedMethod)
+	}
+
+	var sentBody map[string]any
+	if err := json.Unmarshal(receivedBody, &sentBody); err != nil {
+		t.Fatalf("failed to parse sent body: %v", err)
+	}
+	issue, ok := sentBody["issue"].(map[string]any)
+	if !ok {
+		t.Fatal("expected issue key in body")
+	}
+	if issue["notes"] != "更新テスト" {
+		t.Errorf("expected notes 更新テスト, got %v", issue["notes"])
+	}
+}
+
+func TestPut_422ReturnsValidationErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		json.NewEncoder(w).Encode(map[string]any{"errors": []string{"Status is not valid"}})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "key")
+	err := c.Put("/issues/123.json", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Status is not valid") {
+		t.Errorf("expected validation error message, got %q", err.Error())
+	}
+}
+
 func TestDelete_SendsDeleteRequest(t *testing.T) {
 	var receivedMethod string
 	var receivedPath string


### PR DESCRIPTION
## チケット

- close #26

## Why

チケットの作成・検索・関連付けは対応済みだが、更新・削除・コメント記入ができなかった。
SKILL 側（claude-code#13）でも更新スキルを追加するため、CLI 側のコマンドが必要。

## What

### As Is

- チケットの更新・削除コマンドが存在しない
- HTTP クライアントに `Put()` メソッドがない

### To Be

- `update-issue` コマンド: ステータス・担当者・優先度等のフィールド更新、`--notes` によるコメント記入に対応
- `delete-issue` コマンド: チケット削除に対応
- `Put()` メソッドを HTTP クライアントに追加

## Where

- `internal/client/client.go` — `Put()` メソッド追加
- `internal/client/client_test.go` — `Put()` のテスト2件追加
- `cmd/update_issue.go` — `update-issue` コマンド新規作成
- `cmd/delete_issue.go` — `delete-issue` コマンド新規作成

## How

- `Put()` は既存の `Post()` と同パターンで、Redmine の PUT が 204 No Content を返すため result パラメータなし
- `update-issue` は `cmd.Flags().Changed()` で指定されたフラグのみ送信（`create-issue` と同パターン）
- 更新フィールド未指定時はエラーを返すバリデーション付き
- 更新・削除ともに成功時は `{"status": "updated/deleted"}` を JSON 出力